### PR TITLE
Update gcc version listed in developer.html to GCC 14

### DIFF
--- a/developer.html
+++ b/developer.html
@@ -466,7 +466,7 @@
 
 <!-- END OUTPUT from 'modules/contrib/entity_embed/templates/entity-embed-container.html.twig' -->
 
-<p class="text-align-left">Always moving with the latest compiler (llvm, currently GCC 9), optimized for Intel Architecture, giving access to the latest features.</p>
+<p class="text-align-left">Always moving with the latest compiler (llvm, currently GCC 14), optimized for Intel Architecture, giving access to the latest features.</p>
 
 			<p class="text-align-left">Constantly applying compiler flags to optimize builds.</p>
 


### PR DESCRIPTION
Just noticed this browsing the site, and looking at https://github.com/clearlinux-pkgs/gcc I believe clear linux is now shipping GCC 14, and has not been providing GCC 9 for some time.